### PR TITLE
handle new tabs. reintegrate subscrptions

### DIFF
--- a/src/git-tabs.js
+++ b/src/git-tabs.js
@@ -1,3 +1,5 @@
+const {CompositeDisposable} = require('atom');
+
 const git = require('./git');
 
 // PRIVATE METHODS //
@@ -8,10 +10,32 @@ const toggle = () => {
     console.log(git.getBranch());
 };
 
+const handleNewTab = () => {
+    console.log('handling new tab');
+    const branch = git.getBranch();
+    console.log(branch);
+};
+
 module.exports = {
-    activate: () => {
-        atom.commands.add('atom-workspace', {
-            'git-tabs:toggle': () => toggle(),
-        });
+    subscriptions: null,
+
+    activate: function activate() {
+        this.subscriptions = new CompositeDisposable;
+        this.subscriptions.add(
+            atom.commands.add('atom-workspace', {
+                'git-tabs:toggle': () => toggle(),
+            })
+        );
+
+        // subscribe to adding panels
+        this.subscriptions.add(
+            atom.workspace.onDidAddPaneItem(() => {
+                handleNewTab();
+            })
+        );
+    },
+
+    deactivate: function deactivate() {
+        this.subscriptions.dispose();
     },
 };


### PR DESCRIPTION
@john-kelly 
so subscriptions are important for being able to integrate with actions in the editor, in this case adding a new tab/etc.
i reintegrated subscriptions and had to change the function declarations to handle `this`—we can talk about whether or not there's a more es6 way to do this but for right now es6 was just making this harder
