### PR TITLE
Watch .git/HEAD for branch changes

### DIFF
--- a/lib/git-tabs.coffee
+++ b/lib/git-tabs.coffee
@@ -5,38 +5,36 @@ git = require './git'
 module.exports =
   subscriptions: null
   repoSubscriptions: null
+  git: null
 
   activate: (state) ->
     @subscriptions = new CompositeDisposable
 
     # Register command that toggles this view
     @subscriptions.add atom.commands.add 'atom-workspace', 'git-tabs:toggle': => @toggle()
+
+    # Set up git stuff
+    @git = git
+    @git.create()
+
     # Set up git subscriptions
     @subscribeToRepositories()
 
     # subscribe to adding panels
     @subscriptions.add atom.workspace.onDidAddPaneItem ->
       console.log('handling new tab')
-      branch = git.getBranch()
-      console.log(branch)
 
   deactivate: ->
     @subscriptions.dispose()
+    @repoSubscriptions.dispose()
+    @git.destroy()
 
   subscribeToRepositories: ->
-    @repoSubscriptions?.dispose()
-    @repoSubscriptions = new CompositeDisposable
-
-    console.log 'called'
-    for repo in git.getRepositories() when repo?
-      console.log repo
-      @repoSubscriptions.add repo.onDidChangeStatuses =>
-        console.log 'i was called down here'
-        @handleStatusChange()
-
-  handleStatusChange: () ->
-    console.log 'Status changed'
-    console.log git.getBranch()
+    @git.onDidChangeBranch (data) =>
+        @handleBranchChange(data)
 
   toggle: ->
-    console.log('GitTabs was toggled!')
+    console.log 'GitTabs was toggled!'
+
+  handleBranchChange: (data) ->
+    console.log data

--- a/lib/git.coffee
+++ b/lib/git.coffee
@@ -1,20 +1,30 @@
+fs = require 'fs'
+path = require 'path'
+{Emitter, File} = require 'atom'
+
 # Where git is interfaced
+# This is done by watching git files
 module.exports =
-  hasGit: ->
-    return atom.project.getRepositories().length > 0
+  branchWatcher: null
+  emitter: null
 
-  getMainRepo: ->
-    if @hasGit()
-      return atom.project.getRepositories()[0]
-    else
-      return null
+  create: ->
+    @emitter = new Emitter
+    @watchBranches()
 
-  getBranch: ->
-    console.log 'i am here :^)'
-    if @hasGit()
-      return @getMainRepo().getShortHead()
-    else
-      return null
+  destroy: ->
+    @emitter.dispose()
+
+  onDidChangeBranch: (callback) ->
+    @emitter.on 'did-change-branch', callback
+
+  watchBranches: ->
+    gitPaths = @getRepositories()
+    for gitPath in gitPaths
+      gitFile = new File gitPath
+      gitFile.onDidChange =>
+        @emitter.emit 'did-change-branch', {branch: fs.readFileSync(gitPath).toString()}
 
   getRepositories: ->
-    return atom.project.getRepositories()
+      gitPaths = atom.project.getPaths()
+      return (projectPath + '/.git/HEAD' for projectPath in gitPaths)


### PR DESCRIPTION
@john-kelly 
set up an emitter that watches `.git/HEAD` for changes and throws them to the console
`git` might need to be renamed and the way files are handled needs to be structured, evidenced in line 26. 
probably we store the files as `@gitFiles` or something like that
